### PR TITLE
Install GNU tar

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -63,7 +63,7 @@ jobs:
 
     steps:
       - name: Install dependencies
-        run: apk add build-base git postgresql-dev
+        run: apk add build-base git postgresql-dev tar
 
       - name: Check out source code
         uses: actions/checkout@v2


### PR DESCRIPTION
BusyBox `tar` doesn't support the `--posix` option used by `actions/cache`