### PR TITLE
FIX dbconsole to work with IAM token authentication

### DIFF
--- a/lib/pg/aws_rds_iam.rb
+++ b/lib/pg/aws_rds_iam.rb
@@ -32,5 +32,11 @@ module PG
 
       ActiveRecord::Tasks::PostgreSQLDatabaseTasks.prepend ActiveRecordPostgreSQLDatabaseTasks
     end
+
+    if defined?(Rails::DBConsole)
+      require_relative "aws_rds_iam/rails_dbconsole_db_config"
+
+      Rails::DBConsole.prepend RailsDBConsole
+    end
   end
 end

--- a/lib/pg/aws_rds_iam/auth_token_injector.rb
+++ b/lib/pg/aws_rds_iam/auth_token_injector.rb
@@ -23,6 +23,13 @@ module PG
         psql_env["PGPASSWORD"] = generate_auth_token(connection_info)
       end
 
+      def inject_into_env!(configuration_hash)
+        connection_info = ConnectionInfo.from_active_record_configuration_hash(configuration_hash)
+        return unless generate_auth_token?(connection_info)
+
+        ENV["PGPASSWORD"] = generate_auth_token(connection_info)
+      end
+
       private
 
       def generate_auth_token?(connection_info)

--- a/lib/pg/aws_rds_iam/rails_dbconsole/db_config.rb
+++ b/lib/pg/aws_rds_iam/rails_dbconsole/db_config.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module PG
+  module AWS_RDS_IAM
+    module RailsDBConsole
+
+      def db_config
+
+        super.tap do |db_config|
+          AuthTokenInjector.new.inject_into_env! db_config.configuration_hash
+        end
+      end
+    end
+  end
+end

--- a/lib/pg/aws_rds_iam/rails_dbconsole_db_config.rb
+++ b/lib/pg/aws_rds_iam/rails_dbconsole_db_config.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module PG
+  module AWS_RDS_IAM
+    module RailsDBConsole
+    end
+
+    private_constant :RailsDBConsole
+  end
+end
+
+require_relative "rails_dbconsole/db_config"


### PR DESCRIPTION
The rails dbconsole doesn't work with IAM token authentication.

Update pg-aws_rds_iam to enable IAM token authentication with `rails dbconsole`