### PR TITLE
add a small note about sslmode

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ You can set this parameter in
     port: 5432
     database: blog
     aws_rds_iam_auth_token_generator: default
+    sslmode: require # if you are using postgres > 15
   ```
 
 If the default authentication token generator doesn't meet your needs, you can register an alternative with


### PR DESCRIPTION
This is just a small note about setting `sslmode` in Rails because it has been required since postgres 15. Since most people who will copy and paste the example are likely people doing new setups, it wouldn't hurt to have the bit in there to give most people the "just works" experience.

thanks for the great work btw :D
